### PR TITLE
adds missing haunted forest card data

### DIFF
--- a/data/en/beta_files/2022-05-23.json
+++ b/data/en/beta_files/2022-05-23.json
@@ -6032,5 +6032,21 @@
       "Flavor": "",
       "Artist": "Jussi Pylk\u00e4s",
       "FaceURL": "http://cloud-3.steamusercontent.com/ugc/1850427901243858834/8EEE4BC131ACB42152A713CF653997828FA6B872/"
+  },
+  {
+      "Frame": "",
+      "Rarity": "-",
+      "Types": "Site",
+      "Name": "Haunted Forest",
+      "Cost": "",
+      "Threshold": "",
+      "Card Text": "Genesis abilities of adjacent minions are also Deathrite abilities.",
+      "Grid1": "",
+      "Grid2": "",
+      "Power": "",
+      "Type sentence": "A Unique Site of smothering gloom.",
+      "Flavor": "",
+      "Artist": "Ian Miller",
+      "FaceURL": "http://cloud-3.steamusercontent.com/NOPE"
   }
 ]

--- a/data/en/cards/alpha/cards.yaml
+++ b/data/en/cards/alpha/cards.yaml
@@ -1977,6 +1977,18 @@
   mana_cost: '1'
   power: '2'
   wind_threshold: '1'
+- identifier: haunted_forest
+  rarity: unique
+  card_type: site
+  release: alpha
+  artist: ian_miller
+  keywords:
+  - genesis
+  - deathrite
+  name: Haunted Forest
+  rules_box: ! |-
+    Genesis abilities of adjacent minions are also Deathrite abilities.
+  type_line: A Unique Site of smothering gloom.
 - identifier: headless_haunt
   rarity: exceptional
   card_type: minion


### PR DESCRIPTION
Was missing from the beta file. Dug up the image from the content creator file archive.